### PR TITLE
Add directory admin SSH keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .ext/
-/charts/*/build/*-*.*.*.tgz
-/charts/*/charts/*-*.*.*.tgz
+/charts/*/build/
+/charts/*/charts/

--- a/charts/aserto/Chart.lock
+++ b/charts/aserto/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: directory
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.5
+  version: 0.1.6
 - name: authorizer
   repository: oci://ghcr.io/aserto-dev/helm
   version: 0.1.5
@@ -14,5 +14,5 @@ dependencies:
 - name: scim
   repository: oci://ghcr.io/aserto-dev/helm
   version: 0.1.3
-digest: sha256:52549edf4d65b54d9aecfd26cd19974b0606f06a034ff3ac0574e9fea58670a3
-generated: "2024-08-30T07:51:19.880893-04:00"
+digest: sha256:9fdf8504143a355be2ded44d06abcc74423ece9dc4736495ab10d26d08e92043
+generated: "2024-09-10T16:31:54.603385-04:00"

--- a/charts/aserto/Chart.yaml
+++ b/charts/aserto/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,7 +30,7 @@ appVersion: "0.1.0"
 
 dependencies:
   - name: directory
-    version: ~0.1.5
+    version: ~0.1.6
     repository: oci://ghcr.io/aserto-dev/helm
   - name: authorizer
     version: ~0.1.5

--- a/charts/directory/Chart.yaml
+++ b/charts/directory/Chart.yaml
@@ -20,13 +20,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.32.10"
+appVersion: "0.32.11"
 
 dependencies:
   - name: aserto-lib

--- a/charts/directory/templates/admin_keys.yaml
+++ b/charts/directory/templates/admin_keys.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "directory.fullname" . }}-admin-keys
+data:
+  authorized_keys: |
+    {{- .Values.sshAdminKeys | default "" | nindent 4 }}
+

--- a/charts/directory/templates/config.yaml
+++ b/charts/directory/templates/config.yaml
@@ -21,6 +21,8 @@ stringData:
         listen_address: 0.0.0.0:{{ include "aserto-lib.healthPort" . }}
       metrics:
         {{- include "aserto-lib.metricsService" . | nindent 8 }}
+      admin:
+        authorized_keys_path: /admin-keys/authorized_keys
 
     {{ if .Values.rootDirectory.runService }}
     {{- with .Values.rootDirectory.database -}}

--- a/charts/directory/templates/deployment.yaml
+++ b/charts/directory/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        - name: admin-keys
+          configMap:
+            name: {{ include "directory.fullname" . }}-admin-keys
         - name: grpc-certs
         {{- with (include "aserto-lib.grpcConfig" . | fromYaml) }}
         {{- if .certSecret  }}
@@ -75,9 +78,14 @@ spec:
             - name: metrics
               containerPort: {{ .metrics }}
             {{- end }}
+            - containerPort: 2222
+              name: ssh-admin
           volumeMounts:
             - name: config
               mountPath: /config
+              readOnly: true
+            - name: admin-keys
+              mountPath: "/admin-keys"
               readOnly: true
             - name: grpc-certs
               mountPath: /grpc-certs

--- a/charts/directory/values.yaml
+++ b/charts/directory/values.yaml
@@ -19,6 +19,11 @@ image:
 #   domain: ""
 #   audience: ""
 
+# sshAdminKeys: |
+#   # Add your authorized SSH public keys here
+#   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6
+#   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDa7
+
 rootDirectory:
   runService: true
   # REQUIRED: root directory tenant ID


### PR DESCRIPTION
The latest directory exposes an admin ssh endpoint on port 2222.
This PR allows users to provide a set of authorized SSH keys that can connect to the admin endpoint.

The keys are provided in the `directory.sshAdminKeys` value. For example:

```yaml
sshAdminKeys: |
  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6 admin@example.com
  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDa7 owner@example.com
```
