### PR TITLE
Topaz bugfixes

### DIFF
--- a/charts/topaz/Chart.yaml
+++ b/charts/topaz/Chart.yaml
@@ -20,13 +20,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.32.29"
+appVersion: "0.32.31"
 
 dependencies:
   - name: aserto-lib

--- a/charts/topaz/ci/default-values.yaml
+++ b/charts/topaz/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# Intentionally left blank.
+# This tests the chart using its default values.

--- a/charts/topaz/ci/discovery-api-key-values.yaml
+++ b/charts/topaz/ci/discovery-api-key-values.yaml
@@ -1,0 +1,9 @@
+opa:
+  policy:
+    discovery:
+      policyName: "my-policy"
+      tenantID: c102dc4a-f66d-432f-bfa6-b1919dc4fff7
+      apiKey: 84eeee6256e94434aebeea166c99065e
+
+  persistence:
+    enabled: true

--- a/charts/topaz/ci/edge-sync-values.yaml
+++ b/charts/topaz/ci/edge-sync-values.yaml
@@ -1,0 +1,14 @@
+directory:
+  edge:
+    sync:
+      address: "directory.prod.aserto.com:8443"
+      tenantID: c102dc4a-f66d-432f-bfa6-b1919dc4fff7
+
+opa:
+  policy:
+    discovery:
+      policyName: "my-policy"
+      url: https://discovery.prod.aserto.com/api/v2/discovery
+      tenantID: c102dc4a-f66d-432f-bfa6-b1919dc4fff7
+      apiKey: "1234567890"
+

--- a/charts/topaz/ci/edge-sync-values.yaml
+++ b/charts/topaz/ci/edge-sync-values.yaml
@@ -3,7 +3,6 @@ directory:
     sync:
       address: "directory.prod.aserto.com:8443"
       tenantID: c102dc4a-f66d-432f-bfa6-b1919dc4fff7
-
 opa:
   policy:
     discovery:
@@ -11,4 +10,3 @@ opa:
       url: https://discovery.prod.aserto.com/api/v2/discovery
       tenantID: c102dc4a-f66d-432f-bfa6-b1919dc4fff7
       apiKey: "1234567890"
-

--- a/charts/topaz/ci/file-logger-values.yaml
+++ b/charts/topaz/ci/file-logger-values.yaml
@@ -1,0 +1,2 @@
+decisionLogs:
+  enabled: true

--- a/charts/topaz/ci/oci-values.yaml
+++ b/charts/topaz/ci/oci-values.yaml
@@ -1,0 +1,9 @@
+opa:
+  policy:
+    oci:
+      registry: https://ghcr.io
+      # Policy image URI.
+      image: ghcr.io/aserto-policies/policy-todo:latest
+    persistence:
+      enabled: true
+      storage: 20Mi

--- a/charts/topaz/ci/remote-directory-values.yaml
+++ b/charts/topaz/ci/remote-directory-values.yaml
@@ -1,0 +1,5 @@
+directory:
+  remote:
+    apiKeySecret:
+      name: "my-secret"
+      key: "my-key"

--- a/charts/topaz/templates/_helpers.tpl
+++ b/charts/topaz/templates/_helpers.tpl
@@ -253,7 +253,7 @@ connection_timeout_seconds: {{ $cfg.connectionTimeoutSec | default "2" }}
 listen_address: 0.0.0.0:{{ ($values.ports).https | default "8383" }}
 
 {{- if $cfg.domain }}
-fdqn: {{ $cfg.domain }}
+fqdn: {{ $cfg.domain }}
 {{- end }}
 
 {{- if $cfg.allowedHeaders }}

--- a/charts/topaz/templates/_helpers.tpl
+++ b/charts/topaz/templates/_helpers.tpl
@@ -174,7 +174,7 @@ Topaz API key configuration
 {{- define "topaz.discoveryKey" -}}
 {{- if .apiKey -}}
 {{- .apiKey }}
-{{- else if (.apiKeySecret | and .apiKeySecret.name) -}}
+{{- else if (.apiKeySecret | and (.apiKeySecret).name) -}}
 "${DISCOVERY_API_KEY}"
 {{- else }}
 {{ fail "either apiKey or apiKeySecret must be set in opa.policy.discovery" }}
@@ -196,7 +196,7 @@ Topaz API key configuration
 {{- define "topaz.edgeKey" -}}
 {{- if .apiKey -}}
 {{- .apiKey -}}
-{{- else if (.apiKeySecret | and .apiKeySecret.name) -}}
+{{- else if (.apiKeySecret | and (.apiKeySecret).name) -}}
 "${EDGE_API_KEY}"
 {{- end }}
 {{- end }}
@@ -285,6 +285,9 @@ idle_timeout: {{ $cfg.idleTimeout | default "30s" }}
 
 
 {{- define "topaz.discoveryResource" -}}
+{{- if empty .policyName }}
+  {{- fail "opa.policy.discovery.policyName is required" }}
+{{- end }}
 {{- printf "%s/%s/opa" .policyName .policyName }}
 {{- end }}
 
@@ -393,4 +396,13 @@ server:
     {{- fail "controller must contain either mtlsCertSecretName or mtlsCert and mtlsKey" }}
   {{- end }}
 {{- end }}
+{{- end }}
+
+{{- define "topaz.tenantID" -}}
+{{- $discoID := (((.Values.opa).policy).discovery).tenantID }}
+{{- $edgeID := (((.Values.directory).edge).sync).tenantID }}
+{{- if $discoID | and $edgeID | and (eq $discoID $edgeID | not) }}
+  {{ fail "opa.policy.discovery.tenantID and directory.edge.sync.tenantID must match" }}
+{{- end }}
+{{- $discoID | or $edgeID | default "-" }}
 {{- end }}

--- a/charts/topaz/templates/_helpers.tpl
+++ b/charts/topaz/templates/_helpers.tpl
@@ -275,7 +275,7 @@ allowed_origins:
 {{- $origins | toYaml | nindent 2 }}
 
 {{- if $cfg.noTLS }}
-http: false
+http: true
 {{- end }}
 read_timeout: {{ $cfg.readTimeout | default "2s" }}
 read_header_timeout: {{ $cfg.readHeaderTimeout | default "2s" }}

--- a/charts/topaz/templates/_helpers.tpl
+++ b/charts/topaz/templates/_helpers.tpl
@@ -101,13 +101,11 @@ headers:
 
 
 {{- define "topaz.remoteDirectoryKeyEnv" -}}
-{{- with ((.Values.directory).remote).apiKeySecret -}}
 - name: DIRECTORY_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .name }}
       key: {{ .key | default "api-key" }}
-{{- end }}
 {{- end }}
 
 
@@ -155,7 +153,7 @@ Topaz API key configuration
 
 {{- define "topaz.apiKeysEnv" -}}
 {{- $keys := list }}
-{{- range (.Values.auth).apiKeys }}
+{{- range . }}
   {{- if .secretName -}}
     {{- $keys = append $keys . }}
   {{- end }}
@@ -183,13 +181,11 @@ Topaz API key configuration
 
 
 {{- define "topaz.discoveryKeyEnv" -}}
-{{- with (((.Values.opa).policy).discovery).apiKeySecret -}}
 - name: DISCOVERY_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .name }}
       key: {{ .key | default "api-key" }}
-{{- end }}
 {{- end }}
 
 
@@ -202,13 +198,11 @@ Topaz API key configuration
 {{- end }}
 
 {{- define "topaz.edgeKeyEnv" -}}
-{{- with (((.Values.directory).edge).sync).apiKeySecret -}}
 - name: EDGE_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .name }}
       key: {{ .key | default "api-key" }}
-{{- end }}
 {{- end }}
 
 
@@ -224,15 +218,11 @@ Topaz API key configuration
 
 
 {{- define "topaz.svcDependencies" -}}
-{{- $deps := dict "reader" "model" "writer" "model" "importer" "model" "authorizer" "reader" "console" "authorizer" -}}
+{{- $deps := dict "reader" "model" "writer" "model" "importer" "model" "authorizer" "reader" "console" "authorizer" }}
 {{- if $.remote }}
   {{- $deps = unset $deps "authorizer" }}
 {{- end }}
-{{- $dep := get $deps .service -}}
-{{- if $dep -}}
-needs:
-  - {{ $dep }}
-{{- end }}
+{{- get $deps .service }}
 {{- end }}
 
 

--- a/charts/topaz/templates/config.yaml
+++ b/charts/topaz/templates/config.yaml
@@ -10,13 +10,12 @@ stringData:
     # yaml-language-server: $schema=https://topaz.sh/schema/config.json
     ---
     version: 2
-
     logging:
       prod: true
       log_level: {{ .Values.logLevel | default "info" }}
       grpc_log_level: {{ .Values.grpcLogLevel | default "info" }}
 
-    {{ if empty ((.Values.directory).remote).address -}}
+    {{- if empty ((.Values.directory).remote).address }}
     directory:
       db_path: /db/directory.db
       request_timeout: {{ ((.Values.directory).edge).openTimeout | default "5s" }}
@@ -69,7 +68,10 @@ stringData:
       services:
       {{- range (include "topaz.enabledServices" . | fromJsonArray) }}
         {{ . }}:
-          {{- include "topaz.svcDependencies" (dict "service" . "remote" (($.Values.directory).remote).address) | nindent 10 }}
+          {{- with (include "topaz.svcDependencies" (dict "service" . "remote" (($.Values.directory).remote).address)) }}
+          needs:
+            - {{ . }}
+          {{- end }}
           grpc:
             {{- include "topaz.grpcService" (list $.Values .) | nindent 12 }}
             certs:
@@ -87,12 +89,12 @@ stringData:
   {{- if (.Values.decisionLogs).enabled }}
     decision_logger:
       {{- include "topaz.decisionLogger" . | nindent 6 }}
-  {{ end }}
+  {{- end }}
 
-    {{ if (.Values.controller).enabled -}}
+  {{- if (.Values.controller).enabled }}
     controller:
       {{- include "topaz.controller" . | nindent 6 }}
-    {{- end }}
+  {{- end }}
     opa:
       instance_id: {{ include "topaz.tenantID" . }}
       graceful_shutdown_period_seconds: {{ (.Values.opa).gracefuShutdownPeriodSeconds | default "2" }}

--- a/charts/topaz/templates/config.yaml
+++ b/charts/topaz/templates/config.yaml
@@ -24,7 +24,7 @@ stringData:
     remote_directory:
       address: 0.0.0.0:{{ (.Values.ports).grpc | default "8282" }}
       {{- if (.Values.auth).apiKeys }}
-      api_key: {{ include "topaz.apiKeys" . | fromYaml | keys | first }}
+      api_key: {{ include "topaz.apiKeys" . | fromYamlArray | first }}
       {{- end }}
       ca_cert_path: /grpc-certs/grpc-ca.crt
       timeout_in_seconds: {{ ((.Values.directory).remote).timeoutSeconds | default "5" }}
@@ -119,7 +119,7 @@ stringData:
             {{- if $headers }}
               {{- $headers | toYaml | nindent 14 }}
             {{- end }}
-            {{- $cfg | default dict | toYaml | nindent 12 }}
+            {{- $cfg | default (dict "response_header_timeout_seconds" 5) | toYaml | nindent 12 }}
         discovery:
           service: discovery
           resource: {{ include "topaz.discoveryResource" . }}

--- a/charts/topaz/templates/config.yaml
+++ b/charts/topaz/templates/config.yaml
@@ -94,7 +94,7 @@ stringData:
       {{- include "topaz.controller" . | nindent 6 }}
     {{- end }}
     opa:
-      instance_id: {{ (((.Values.opa).policy).discovery).tenantID | default (quote "-") }}
+      instance_id: {{ include "topaz.tenantID" . }}
       graceful_shutdown_period_seconds: {{ (.Values.opa).gracefuShutdownPeriodSeconds | default "2" }}
       max_plugin_wait_time_seconds: {{ (.Values.opa).maxPluginWaitTimeSeconds | default "30" }}
       local_bundles:
@@ -153,7 +153,9 @@ stringData:
           {{- with .Values.directory.edge.sync }}
           aserto_edge:
             addr: {{ .address }}
-            apikey: {{ include "topaz.edgeKey" . | default "" }}
+            {{- with include "topaz.edgeKey" . }}
+            apikey: {{ . }}
+            {{- end }}
             enabled: true
             insecure: {{ .skipTLSVerification | default false | toString }}
             sync_interval: {{ .intervalMinutes | default "1" }}

--- a/charts/topaz/templates/deployment.yaml
+++ b/charts/topaz/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             {{- end }}
           {{- with (.Values.directory).remote -}}
             {{ include "topaz.remoteDirectoryCertVolumeMount" . | nindent 12 }}
-          {{- end -}}
+          {{- end }}
           {{- if (.Values.decisionLogs).remote }}
             - name: scribe-cert
               mountPath: /scribe-cert
@@ -99,16 +99,24 @@ spec:
             - name: controller-cert
               mountPath: /controller-cert
           {{- end }}
-            {{- with .Values.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
+            {{- with .Values.volumeMounts -}}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: TOPAZ_CFG_DIR
               value: /config
+          {{- with ((.Values.directory).remote).apiKeySecret -}}
             {{ include "topaz.remoteDirectoryKeyEnv" . | nindent 12 }}
+          {{- end }}
+          {{- with (.Values.auth).apiKeys -}}
             {{ include "topaz.apiKeysEnv" . | nindent 12 }}
+          {{- end }}
+          {{- with (((.Values.directory).edge).sync).apiKeySecret -}}
             {{ include "topaz.edgeKeyEnv" . | nindent 12 }}
+          {{- end }}
+          {{- with (((.Values.opa).policy).discovery).apiKeySecret -}}
             {{ include "topaz.discoveryKeyEnv" . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: config
           secret:


### PR DESCRIPTION
Fixes:
* https://github.com/aserto-dev/helm/issues/18
* `http.domain` was generating invalid `fdqn` field instead of `fqdn`
* No error when `policyName` is omitted in `opa.policy.discovery`.
* Added check that if both `opa.policy.discovery.tenantID` and `directory.edge.sync.tenantID` are specified, their values match.
* Include tenant ID in opa configuration when edge sync is enabled even when discovery isn't used.
* Fix invalid `{}` literal when `opa.policy.discovery.serviceConfig` is empty.