### PR TITLE
Quote opa `instance_id` field

### DIFF
--- a/charts/topaz/Chart.yaml
+++ b/charts/topaz/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topaz/templates/_helpers.tpl
+++ b/charts/topaz/templates/_helpers.tpl
@@ -394,5 +394,5 @@ server:
 {{- if $discoID | and $edgeID | and (eq $discoID $edgeID | not) }}
   {{ fail "opa.policy.discovery.tenantID and directory.edge.sync.tenantID must match" }}
 {{- end }}
-{{- $discoID | or $edgeID | default "-" }}
+{{- $discoID | or $edgeID | default "-" | quote }}
 {{- end }}


### PR DESCRIPTION
This fixes a bug that causes the output to be invalid yaml:

```yaml
opa:
  instance_id: -
  ...
```