### PR TITLE
added checksum/config annotation to ensure pod restarts when new config is applied

### DIFF
--- a/charts/topaz/templates/deployment.yaml
+++ b/charts/topaz/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "topaz.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
When the following is run after making a config change.

```console
helm upgrade --install topaz . -f topaz.yaml --namespace topaz --create-namespace
```

helm will restart the pod so that the new config can be applied.

```console
kubectl get pods -w
NAME      READY   STATUS    RESTARTS   AGE
topaz-0   1/1     Running   0          66s
topaz-0   1/1     Terminating   0          117s
topaz-0   0/1     Terminating   0          118s
topaz-0   0/1     Terminating   0          118s
topaz-0   0/1     Terminating   0          118s
topaz-0   0/1     Terminating   0          118s
topaz-0   0/1     Pending       0          0s
topaz-0   0/1     Pending       0          0s
topaz-0   0/1     ContainerCreating   0          0s
topaz-0   0/1     Running             0          1s
topaz-0   0/1     Running             0          12s
topaz-0   1/1     Running             0          16s
```