### PR TITLE
Directory tenants

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -43,7 +44,7 @@ jobs:
         with:
           version: v3.10.0
       -
-        name: Lint ${{ matrix.chart.name }}
+        name: Lint
         run: |
           ct lint --config ct.yaml \
             --target-branch ${{ github.event.repository.default_branch }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,4 @@ jobs:
       -
         name: Lint
         run: |
-          ct lint --config ct.yaml \
-            --target-branch ${{ github.event.repository.default_branch }} \
-            --helm-repo-extra-args "aserto-helm=-u gh -p ${READ_WRITE_TOKEN}"
+          ct lint --config ct.yaml --helm-repo-extra-args "aserto-helm=-u gh -p ${READ_WRITE_TOKEN}"

--- a/charts/aserto-lib/Chart.yaml
+++ b/charts/aserto-lib/Chart.yaml
@@ -21,7 +21,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/aserto-lib/templates/_clusteraddr.tpl
+++ b/charts/aserto-lib/templates/_clusteraddr.tpl
@@ -17,7 +17,11 @@ Args: [scope, config, service]
 {{- tpl $addr $scope }}
 {{- else }}
 {{- $port := include "aserto-lib.ports" (list $scope $cfg) | fromYaml | dig $portType ""  | toYaml }}
+{{- if contains $svc $scope.Release.Name }}
+{{- printf "%s.%s.svc.cluster.local:%s" $scope.Release.Name $scope.Release.Namespace $port }}
+{{- else }}
 {{- printf "%s-%s.%s.svc.cluster.local:%s" $scope.Release.Name $svc $scope.Release.Namespace $port }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/aserto-lib/templates/_config.tpl
+++ b/charts/aserto-lib/templates/_config.tpl
@@ -31,5 +31,5 @@ Root directory tenant ID
 */}}
 {{- define "aserto-lib.rootDirectoryTenantID" -}}
 {{- (include "aserto-lib.rootDirectoryCfg" . | fromYaml).tenantID |
-	required ".Values.rootDirectory.tenantID or .Values.global.aserto.rootDirectory.tenantID must be set" -}}
+	default "06e1fdac-0676-11ef-b77e-0005a79d9368" -}}
 {{- end }}

--- a/charts/aserto-lib/templates/_config.tpl
+++ b/charts/aserto-lib/templates/_config.tpl
@@ -31,5 +31,5 @@ Root directory tenant ID
 */}}
 {{- define "aserto-lib.rootDirectoryTenantID" -}}
 {{- (include "aserto-lib.rootDirectoryCfg" . | fromYaml).tenantID |
-	default "06e1fdac-0676-11ef-b77e-0005a79d9368" -}}
+	default "00000000-0000-11ef-0000-000000000000" -}}
 {{- end }}

--- a/charts/aserto/Chart.lock
+++ b/charts/aserto/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: directory
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.7
+  version: 0.1.9
 - name: authorizer
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.6
+  version: 0.1.7
 - name: discovery
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.5
+  version: 0.1.6
 - name: console
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.5
+  version: 0.1.6
 - name: scim
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:62f06ef22f89eab79e44787a57c9377faf11d5fb14cf799f0ff63c1dcf127798
-generated: "2024-10-24T12:12:29.438424-04:00"
+  version: 0.1.5
+digest: sha256:980022ba59e0ff9d2eef12e29607db9c7f579ded5286bf71e63d4181863d530d
+generated: "2024-11-12T16:41:28.881217-05:00"

--- a/charts/aserto/Chart.yaml
+++ b/charts/aserto/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,17 +31,17 @@ appVersion: "0.1.0"
 
 dependencies:
   - name: directory
-    version: ~0.1.7
+    version: ~0.1.9
     repository: oci://ghcr.io/aserto-dev/helm
   - name: authorizer
-    version: ~0.1.6
+    version: ~0.1.7
     repository: oci://ghcr.io/aserto-dev/helm
   - name: discovery
-    version: ~0.1.5
+    version: ~0.1.6
     repository: oci://ghcr.io/aserto-dev/helm
   - name: console
-    version: ~0.1.5
+    version: ~0.1.6
     repository: oci://ghcr.io/aserto-dev/helm
   - name: scim
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/aserto/ci/test-values.yaml
+++ b/charts/aserto/ci/test-values.yaml
@@ -1,3 +1,4 @@
+---
 global:
   aserto:
     oidc:
@@ -13,9 +14,10 @@ discovery:
       tokenSecretName: ghcr-token-secret
 directory:
   rootDirectory:
-    tenantID: root-tenant-id
     database:
       host: root-db-host
   tenantDirectory:
     database:
       host: tenant-db-host
+  sshAdminKeys: |
+    ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6

--- a/charts/aserto/values.yaml
+++ b/charts/aserto/values.yaml
@@ -1,3 +1,4 @@
+---
 global:
   # Configuration shared by all services.
   aserto:
@@ -62,7 +63,7 @@ directory:
   #   tag: x.y.z
   #   pullPolicy: IfNotPresent
 
-  # Control access to the directory's management service.
+  # Required: Provide one or more SSH public keys to be granted admin access.
   # sshAdminKeys: |
   #   # Add your authorized SSH public keys here
   #   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6

--- a/charts/aserto/values.yaml
+++ b/charts/aserto/values.yaml
@@ -32,7 +32,7 @@ global:
       # [REQUIRED] Specify the ingress address of the
       # conosle service.
       allowed_origins:
-        # - https://console.aserto.example.com
+      # - https://console.aserto.example.com
 
 
     # # Metrics configuration.
@@ -46,8 +46,6 @@ global:
     rootDirectory:
       # Disable TLS verification on
       disableTLSVerification: true
-      # Tenant ID of the root directory.
-      tenantID: 06e1fdac-0676-11ef-b77e-0005a79d9368
 
     directory:
       disableTLSVerification: true

--- a/charts/authorizer/Chart.lock
+++ b/charts/authorizer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:07:51.34431-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:32:41.420861-05:00"

--- a/charts/authorizer/Chart.yaml
+++ b/charts/authorizer/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,5 +31,5 @@ appVersion: "0.14.8"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/authorizer/ci/test-values.yaml
+++ b/charts/authorizer/ci/test-values.yaml
@@ -1,5 +1,4 @@
-rootDirectory:
-  tenantID: root-tenant-id
+---
 oidc:
   domain: oidc_domain
   audience: oidc_audience

--- a/charts/console/Chart.lock
+++ b/charts/console/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:09:17.129418-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:33:55.906929-05:00"

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,5 +31,5 @@ appVersion: "0.1.13"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for directory.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -18,7 +19,6 @@ oidc:
   audience: ""
 
 rootDirectory:
-  tenantID: "06e1fdac-0676-11ef-b77e-0005a79d9368"
   disableTLSVerification: false
   grpcCertSecret: ""
   # address: "{{ .Release.Name }}-aserto-directory.aserto.svc.cluster.local:8282"

--- a/charts/directory/Chart.lock
+++ b/charts/directory/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:09:49.990987-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:34:28.799109-05:00"

--- a/charts/directory/Chart.yaml
+++ b/charts/directory/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.32.11"
+appVersion: "0.33.1"
 
 dependencies:
   - name: aserto-lib

--- a/charts/directory/Chart.yaml
+++ b/charts/directory/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,5 +31,5 @@ appVersion: "0.33.1"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/directory/ci/minimal-values.yaml
+++ b/charts/directory/ci/minimal-values.yaml
@@ -1,3 +1,4 @@
+---
 global:
   aserto:
     imagePullSecrets:
@@ -9,3 +10,5 @@ rootDirectory:
 tenantDirectory:
   database:
     host: tenant-db-host
+sshAdminKeys: |
+  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6

--- a/charts/directory/ci/minimal-values.yaml
+++ b/charts/directory/ci/minimal-values.yaml
@@ -4,7 +4,6 @@ global:
     imagePullSecrets:
       - name: ghcr-creds
 rootDirectory:
-  tenantID: root-tenant-id
   database:
     host: root-db-host
 tenantDirectory:

--- a/charts/directory/ci/tenants-values.yaml
+++ b/charts/directory/ci/tenants-values.yaml
@@ -1,0 +1,22 @@
+---
+rootDirectory:
+  tenantID: root-tenant-id
+  database:
+    host: root-db-host
+tenantDirectory:
+  database:
+    host: tenant-db-host
+sshAdminKeys: |
+  ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6
+tenants:
+  - name: staging
+    id: 3dbaa470-9c7e-11ef-bf36-00fcb2a75cb1
+    keysSecret:
+      name: staging-keys
+      writerKey: writerKey
+      readerKey: readerKey
+  - name: prod
+    id: 8b6152d2-9d19-11ef-98b6-00a83bc65178
+    keys:
+      writer: fb634e791176409a8c5dd6776435fb0b
+      reader: 39fa2ac0eb0f45fdb9234bb69436940f

--- a/charts/directory/ci/tenants-values.yaml
+++ b/charts/directory/ci/tenants-values.yaml
@@ -1,6 +1,5 @@
 ---
 rootDirectory:
-  tenantID: root-tenant-id
   database:
     host: root-db-host
 tenantDirectory:

--- a/charts/directory/templates/_helpers.tpl
+++ b/charts/directory/templates/_helpers.tpl
@@ -67,14 +67,14 @@ Create the name of the service account to use
 {{- end -}}
 {{- if .keysSecret -}}
 - key: {{ printf "${TENANT_%s_WRITER_KEY}" (replace "." "_" .name | upper) }}
-  account: directory-client-writer@{{ .id }}@aserto.com
+  account: directory-client-writer@{{ .id }}.aserto.com
 - key: {{ printf "${TENANT_%s_READER_KEY}" (replace "." "_" .name | upper) }}
-  account: directory-client-reader@{{ .id }}@aserto.com
+  account: directory-client-reader@{{ .id }}.aserto.com
 {{- else if .keys -}}
 - key: {{ .keys.writer | required "tenants[].keys.writer is required" }}
-  account: directory-client-writer@{{ .id }}@aserto.com
+  account: directory-client-writer@{{ .id }}.aserto.com
 - key: {{ .keys.reader | required "tenants[].keys.reader is required" }}
-  account: directory-client-reader@{{ .id }}@aserto.com
+  account: directory-client-reader@{{ .id }}.aserto.com
 {{- else -}}
   {{ fail "all tenants must include either 'keys' or 'keysSecret'" }}
 {{- end }}

--- a/charts/directory/templates/_helpers.tpl
+++ b/charts/directory/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "directory.tenantKeys" -}}
+{{- if empty .name -}}
+	{{- fail "tenants[].name is require" }}
+{{- end -}}
+{{- if .keysSecret -}}
+- key: {{ printf "${TENANT_%s_WRITER_KEY}" (replace "." "_" .name | upper) }}
+  account: directory-client-writer@{{ .id }}@aserto.com
+- key: {{ printf "${TENANT_%s_READER_KEY}" (replace "." "_" .name | upper) }}
+  account: directory-client-reader@{{ .id }}@aserto.com
+{{- else if .keys -}}
+- key: {{ .keys.writer | required "tenants[].keys.writer is required" }}
+  account: directory-client-writer@{{ .id }}@aserto.com
+- key: {{ .keys.reader | required "tenants[].keys.reader is required" }}
+  account: directory-client-reader@{{ .id }}@aserto.com
+{{- else -}}
+  {{ fail "all tenants must include either 'keys' or 'keysSecret'" }}
+{{- end }}
+{{- end}}

--- a/charts/directory/templates/admin_keys.yaml
+++ b/charts/directory/templates/admin_keys.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ include "directory.fullname" . }}-admin-keys
 data:
   authorized_keys: |
-    {{- .Values.sshAdminKeys | default "" | nindent 4 }}
+    {{- .Values.sshAdminKeys | required  "sshAdminKeys is required" | nindent 4 }}
 

--- a/charts/directory/templates/config.yaml
+++ b/charts/directory/templates/config.yaml
@@ -109,13 +109,15 @@ stringData:
     authentication:
       authenticators_enabled:
         root_key: true
+        {{- with .Values.oidc }}
         oidc: true
+        {{- end }}
         {{- if (.Values.authentication).machineAccounts }}
         machine_account: true
         {{- end }}
 
       root_keys:
-        {{- if .Values.tenantDirectory.runService }}
+      {{- if .Values.tenantDirectory.runService }}
         keys:
           - key: ${DIRECTORY_DS_WRITE_KEY}
             account: root-key-directory-writer@aserto.com
@@ -124,21 +126,27 @@ stringData:
           - key: ${DIRECTORY_ROOT_DS_CLIENT_API_KEY}
             account: root-key-directory-store-writer@aserto.com
 
-        {{- if .Values.rootDirectory.runService }}
+        {{ if .Values.rootDirectory.runService -}}
         tenant_overrides:
           {{ include "aserto-lib.rootDirectoryTenantID" .}}:
             - key: ${DIRECTORY_ROOT_DS_CLIENT_API_KEY}
               account: "root-ds"
+        {{- range .Values.tenants }}
+          {{ .id | required "all tenants must have an id." }}:
+            {{- include "directory.tenantKeys" . | nindent 12 }}
+        {{- end }}
         {{- end }}
 
-        {{- else }}
+      {{- else }}
         keys:
           - key: ${DIRECTORY_ROOT_DS_CLIENT_API_KEY}
             account: "root-ds"
-        {{- end }}
+      {{- end }}
 
+      {{- with .Values.oidc -}}
       oidc:
         {{- include "aserto-lib.oidcConfig" . | nindent 8 }}
+      {{- end }}
 
       override:
         - methods:

--- a/charts/directory/templates/deployment.yaml
+++ b/charts/directory/templates/deployment.yaml
@@ -174,6 +174,22 @@ spec:
                   key: password
             {{- end }}
             {{- end }}
+
+          {{- range $_, $tenant := .Values.tenants -}}
+            {{- with $tenant.keysSecret }}
+            - name: {{ printf "TENANT_%s_WRITER_KEY" (replace "." "_" $tenant.name | upper) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | required "tenants[].keysSecret.name is required" }}
+                  key: {{ .writerKey | default "writer" }}
+            - name: {{ printf "TENANT_%s_READER_KEY" (replace "." "_" $tenant.name | upper) }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | required "tenants[].keysSecret.name is required" }}
+                  key: {{ .readerKey | default "reader" }}
+            {{- end }}
+          {{- end }}
+
           {{- with (include "aserto-lib.selfPorts" . | fromYaml )}}
           livenessProbe:
             grpc:

--- a/charts/directory/templates/deployment.yaml
+++ b/charts/directory/templates/deployment.yaml
@@ -13,8 +13,10 @@ spec:
       {{- include "directory.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/admin_keys: {{ include (print $.Template.BasePath "/admin_keys.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/directory/values.yaml
+++ b/charts/directory/values.yaml
@@ -1,24 +1,26 @@
 # Default values for directory.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
+---
 image:
   repository: ghcr.io/aserto-dev/directory
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # tag: x.y.z
 
+# Optional: override default ports.
 # ports:
-  # grpc: 8282
-  # https: 8383
-  # health: 8484
-  # metrics: 8585
+#   grpc: 8282
+#   https: 8383
+#   health: 8484
+#   metrics: 8585
 
-# REQUIRED: specify and OIDC domain and audience
-# oidc:
+# Optional: OpenID Connect domain and audience.
+oidc:
 #   domain: ""
 #   audience: ""
 
+# Required: Provide one or more SSH public keys to be granted admin access.
 # sshAdminKeys: |
 #   # Add your authorized SSH public keys here
 #   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDf6
@@ -79,6 +81,21 @@ tenantDirectory:
         max_idle_conns: 25
         conn_max_lifetime: 5
         query_timeout_seconds: 5
+
+# Optional: list of predefined tenants.
+tenants:
+#   - name: my-tenant
+#     id: 3dbaa470-9c7e-11ef-bf36-00fcb2a75cb1
+#     # Read-only and read-write API keys for the tenant.
+#     keys:
+#       writer: fb634e791176409a8c5dd6776435fb0b
+#       reader: 39fa2ac0eb0f45fdb9234bb69436940f
+#     # Kubernetes secret containing API keys for the tenant.
+#     # If 'keysSecret' is provided, 'keys' is ignored.
+#     keysSecret:
+#       name: my-tenant-keys
+#       writerKey: writer
+#       readerKey: reader
 
 
 # Set the service log level (trace/debug/info/warn/error)

--- a/charts/directory/values.yaml
+++ b/charts/directory/values.yaml
@@ -28,9 +28,6 @@ oidc:
 
 rootDirectory:
   runService: true
-  # REQUIRED: root directory tenant ID
-  tenantID: ""
-
   database:
     # REQUIRED: root directory database hostname
     host: ""

--- a/charts/discovery/Chart.lock
+++ b/charts/discovery/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:10:15.253039-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:34:55.39824-05:00"

--- a/charts/discovery/Chart.yaml
+++ b/charts/discovery/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,5 +31,5 @@ appVersion: "0.1.3"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/discovery/ci/test-values.yaml
+++ b/charts/discovery/ci/test-values.yaml
@@ -1,8 +1,7 @@
+---
 oidc:
   domain: oidc_domain
   audience: oidc_audience
-rootDirectory:
-  tenantID: root-tenant-id
 registries:
   ghcr.io:
     scheme: bearer

--- a/charts/scim/Chart.lock
+++ b/charts/scim/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:10:39.84766-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:35:17.368622-05:00"

--- a/charts/scim/Chart.yaml
+++ b/charts/scim/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -31,5 +31,5 @@ appVersion: "0.0.7"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/scim/values.yaml
+++ b/charts/scim/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for directory.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -17,8 +18,6 @@ global:
       metrics: 8585
 
     rootDirectory:
-      # global override for rootDirectory.tenantID
-      tenantID: ""
       address: ""
       grpcCertSecret: ""
 
@@ -44,7 +43,6 @@ port: 8080
 # userMappings: []
 
 rootDirectory:
-  tenantID: "06e1fdac-0676-11ef-b77e-0005a79d9368"
   disableTLSVerification: false
   grpcCertSecret: ""
   # address: "{{ .Release.Name }}-aserto-directory.aserto.svc.cluster.local:8282"

--- a/charts/topaz/Chart.lock
+++ b/charts/topaz/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: aserto-lib
   repository: oci://ghcr.io/aserto-dev/helm
-  version: 0.1.4
-digest: sha256:018291c7638b93c7e47707393a5f72872ecb4ff06670fa660637392fdc28c873
-generated: "2024-10-24T12:11:00.463017-04:00"
+  version: 0.1.5
+digest: sha256:d4b6f4909c81802d39c520b76bbcd5a1f7f9897d0b20cee02a9978f3a5b14447
+generated: "2024-11-12T16:35:42.713729-05:00"

--- a/charts/topaz/Chart.yaml
+++ b/charts/topaz/Chart.yaml
@@ -31,5 +31,5 @@ appVersion: "0.32.33"
 
 dependencies:
   - name: aserto-lib
-    version: ~0.1.4
+    version: ~0.1.5
     repository: oci://ghcr.io/aserto-dev/helm

--- a/charts/topaz/artifacthub-repo.yml
+++ b/charts/topaz/artifacthub-repo.yml
@@ -1,0 +1,9 @@
+---
+# Artifact Hub repository metadata file
+repositoryID: 43be4ce9-998c-4efb-8a2d-01f1ce615b4c
+owners:  # (used to claim repository ownership)
+  - name: ronenh
+    email: github@ronen.hilewi.cz
+ignore:  # (pre-releases should not be indexed by Artifact Hub)
+  - name: topaz
+    version: beta # Regular expression (when omitted, all versions are ignored)

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
+---
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
-target-branch: main
+target-branch: published
 chart-repos:
   - aserto-helm=oci://ghcr.io/aserto-dev/helm


### PR DESCRIPTION
This PR adds configuration options for tenant API keys in the directory chart.

Tenants can be defined in `values.yaml` using:
```yaml
tenants:
  - name: staging
    id: 3dbaa470-9c7e-11ef-bf36-00fcb2a75cb1
    keysSecret:
      name: staging-keys
      writerKey: writerKey
      readerKey: readerKey
  - name: prod
    id: 8b6152d2-9d19-11ef-98b6-00a83bc65178
    keys:
      writer: fb634e791176409a8c5dd6776435fb0b
      reader: 39fa2ac0eb0f45fdb9234bb69436940f
```

The keys for the first tenant (`staging`) are read from the specified k8s secret.
The keys for the second are provided inline.


This PR also sets `checksum` annotations the trigger pod restarts when configuration changes.