### PR TITLE
Update charts to latest service versions with no TLS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,14 +89,14 @@ jobs:
         env:
           TOPAZ_CERTS_DIR: ${{ env.TOPAZ_CERTS_DIR }}
         run: |
-          uv run --project tools/ktest tools/ktest/ktest.py charts/topaz/test/tests.yaml
+          make test-topaz
       -
         name: Test Discovery
         timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run --project tools/ktest tools/ktest/ktest.py charts/discovery/test/tests.yaml
+          make test-discovery
       -
         name: Deploy Postgres
         run: |
@@ -132,4 +132,4 @@ jobs:
           SSH_PRIVATE_KEY: ${{ steps.sshkey.outputs.private_key }}
           TOPAZ_CERTS_DIR: ${{ env.TOPAZ_CERTS_DIR }}
         run: |
-          uv run --project tools/ktest tools/ktest/ktest.py charts/directory/test/tests.yaml
+          make test-directory

--- a/charts/aserto-lib/templates/_config.tpl
+++ b/charts/aserto-lib/templates/_config.tpl
@@ -47,12 +47,12 @@ Takes a k8s resource retrieved using the `lookup` function and returns true
 if the resource is managed by the current helm release. False otherwise.
 */}}
 {{- define "aserto-lib.isManagedResource" -}}
-{{- $resource := first . | default dict}}
+{{- $resource := first . | default dict }}
 {{- $releaseName := last . }}
 {{- if $resource | dig "metadata" "labels" "app.kubernetes.io/managed-by" "" | eq "Helm" | and
-       ($resource | dig "metadata" "annotations" "meta.helm.sh/release-name" "" | eq $releaseName) }}
+       ($resource | dig "metadata" "annotations" "meta.helm.sh/release-name" "" | eq $releaseName) -}}
 true
-{{- else }}
+{{- else -}}
 false
 {{- end }}
 {{- end }}

--- a/charts/aserto-lib/templates/_config.tpl
+++ b/charts/aserto-lib/templates/_config.tpl
@@ -41,3 +41,18 @@ Root directory tenant ID
 {{- (include "aserto-lib.rootClientCfg" . | fromYaml).tenantID |
 	default "00000000-0000-11ef-0000-000000000000" -}}
 {{- end }}
+
+{{/*
+Takes a k8s resource retrieved using the `lookup` function and returns true
+if the resource is managed by the current helm release. False otherwise.
+*/}}
+{{- define "aserto-lib.isManagedResource" -}}
+{{- $resource := first . }}
+{{- $releaseName := last . }}
+{{- if get ($resource.metadata).labels "app.kubernetes.io/managed-by" | eq "Helm" | and
+      (get ($resource.metadata).annotations "meta.helm.sh/release-name" | eq $releaseName) }}
+true
+{{- else }}
+false
+{{- end }}
+{{- end }}

--- a/charts/aserto-lib/templates/_config.tpl
+++ b/charts/aserto-lib/templates/_config.tpl
@@ -47,10 +47,10 @@ Takes a k8s resource retrieved using the `lookup` function and returns true
 if the resource is managed by the current helm release. False otherwise.
 */}}
 {{- define "aserto-lib.isManagedResource" -}}
-{{- $resource := first . }}
+{{- $resource := first . | default dict}}
 {{- $releaseName := last . }}
-{{- if get ($resource.metadata).labels "app.kubernetes.io/managed-by" | eq "Helm" | and
-      (get ($resource.metadata).annotations "meta.helm.sh/release-name" | eq $releaseName) }}
+{{- if $resource | dig "metadata" "labels" "app.kubernetes.io/managed-by" "" | eq "Helm" | and
+       ($resource | dig "metadata" "annotations" "meta.helm.sh/release-name" "" | eq $releaseName) }}
 true
 {{- else }}
 false

--- a/charts/aserto/Chart.lock
+++ b/charts/aserto/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 0.2.2
 - name: authorizer
   repository: file://../authorizer
-  version: 0.1.9
+  version: 0.1.10
 - name: discovery
   repository: file://../discovery
   version: 0.1.9
@@ -20,5 +20,5 @@ dependencies:
 - name: registry-proxy
   repository: file://../registry-proxy
   version: 0.1.6
-digest: sha256:aa36828e3a9be09c32aca35e76785be6fea7a9cce866cf929effed6c38216635
-generated: "2025-01-08T18:26:30.831721-05:00"
+digest: sha256:a416841691e59b989714a06b49fdb540de61094d3ebbc5e935eb85b53f11387e
+generated: "2025-01-10T12:41:01.715504-05:00"

--- a/charts/aserto/Chart.yaml
+++ b/charts/aserto/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: file://../directory
     condition: directory.enabled
   - name: authorizer
-    version: 0.1.9
+    version: 0.1.10
     repository: file://../authorizer
     condition: authorizer.enabled
   - name: discovery

--- a/charts/aserto/values.yaml
+++ b/charts/aserto/values.yaml
@@ -135,7 +135,7 @@ discovery:
     #   tokenSecretKey: token
 
 console:
-  enabled: false
+  enabled: true
   # Kubernetes pull secret for private Aserto images.
   # imagePullSecrets:
   #   - name: ghcr-creds

--- a/charts/authorizer/Chart.yaml
+++ b/charts/authorizer/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.1.9
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.8"
+appVersion: "0.15.7"
 
 dependencies:
   - name: aserto-lib

--- a/charts/authorizer/Chart.yaml
+++ b/charts/authorizer/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.15.7"
+appVersion: 0.15.8
 
 dependencies:
   - name: aserto-lib

--- a/charts/authorizer/templates/api_keys.yaml
+++ b/charts/authorizer/templates/api_keys.yaml
@@ -1,13 +1,18 @@
+{{- with .Values.apiKey -}}
+{{- $secret :=  lookup "v1" "Secret" $.Release.Namespace .secretName }}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret $.Release.Name) | toYaml ) -}}
+
 ---
-{{- $cfg := .Values.apiKey -}}
-{{- $data :=  (lookup "v1" "Secret" .Release.Namespace $cfg.secretName).data }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $cfg.secretName }}
+  name: {{ .secretName }}
 data:
-  {{- if $data }}
-  {{ $cfg.secretKey }}: {{ get $data $cfg.secretKey }}
-  {{- else }}
-  {{ $cfg.secretKey }}: {{ randAlphaNum 20 | b64enc }}
-  {{- end }}
+{{- if ($secret).data }}
+  {{ .secretKey }}: {{ get $secret.data .secretKey }}
+{{- else }}
+  {{ .secretKey }}: {{ randAlphaNum 20 | b64enc }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/charts/authorizer/templates/api_keys.yaml
+++ b/charts/authorizer/templates/api_keys.yaml
@@ -1,6 +1,6 @@
 {{- with .Values.apiKey -}}
 {{- $secret :=  lookup "v1" "Secret" $.Release.Namespace .secretName }}
-{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret $.Release.Name) | toYaml ) -}}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret $.Release.Name) | eq "true" ) -}}
 
 ---
 apiVersion: v1

--- a/charts/authorizer/templates/deployment.yaml
+++ b/charts/authorizer/templates/deployment.yaml
@@ -31,43 +31,35 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
-        - name: grpc-certs
-          {{- with include "aserto-lib.grpcConfig" . | fromYaml }}
-          {{- if .certSecret  }}
-          secret:
-            secretName: {{ .certSecret }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-          {{- end }}
-        - name: https-certs
-          {{- with (include "aserto-lib.httpsConfig" . | fromYaml) }}
-          {{- if .certSecret }}
-          secret:
-            secretName: {{ .certSecret }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-          {{- end }}
 
-        {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}        
+        {{- with (include "aserto-lib.grpcConfig" . | fromYaml).certSecret }}
+        - name: grpc-certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+
+        {{- with (include "aserto-lib.httpsConfig" . | fromYaml).certSecret }}
+        - name: https-certs
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+
+        {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}
         - name: root-ds-grpc-certs
           secret:
             secretName: {{ . }}
             items:
               - key: ca.crt
-                path: ca.crt        
+                path: ca.crt
         {{- end }}
 
-        {{- with (include "aserto-lib.discoveryCfg" . | fromYaml) }}
-        {{- if .httpsCertSecret }}
+        {{- with (include "aserto-lib.discoveryCfg" . | fromYaml).httpsCertSecret }}
         - name: discovery-https-certs
           secret:
-            secretName: {{ .httpsCertSecret }}
+            secretName: {{ . }}
             items:
               - key: ca.crt
                 path: ca.crt
-        {{- end }}
         {{- end }}
 
       containers:
@@ -90,18 +82,20 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
+
+          {{- with (include "aserto-lib.grpcConfig" . | fromYaml).certSecret }}
             - name: grpc-certs
               mountPath: /grpc-certs
-            {{- if (include "aserto-lib.grpcConfig" . | fromYaml).certSecret  }}
               readOnly: true
-            {{- end }}
+          {{- end }}
+
+          {{- with (include "aserto-lib.httpsConfig" . | fromYaml).certSecret }}
             - name: https-certs
               mountPath: /https-certs
-            {{- if (include "aserto-lib.httpsConfig" . | fromYaml).certSecret  }}
               readOnly: true
-            {{- end }}
+          {{- end }}
 
-          {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}        
+          {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}
             - name: root-ds-grpc-certs
               mountPath: /root-ds-grpc-certs
               readOnly: true
@@ -115,6 +109,7 @@ spec:
           env:
             - name: AUTHORIZER_DS0_API_KEY
               {{ include "aserto-lib.rootApiKeyEnv" . | nindent 14 }}
+
           {{- with .Values.apiKey }}
             - name: AUTHORIZER_ROOT_KEY
               valueFrom:

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.1.8
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.14"
+appVersion: "0.1.17"
 
 dependencies:
   - name: aserto-lib

--- a/charts/directory/Chart.yaml
+++ b/charts/directory/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.2.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.33.5"
+appVersion: 0.33.6
 
 dependencies:
   - name: aserto-lib

--- a/charts/directory/templates/api_keys.yaml
+++ b/charts/directory/templates/api_keys.yaml
@@ -1,18 +1,23 @@
 {{- if .Values.rootDirectory.runService }}
 {{- $cfg := include "aserto-lib.directoryApiKeys" . | fromYaml -}}
-{{- $data :=  (lookup "v1" "Secret" .Release.Namespace $cfg.secretName).data }}
+{{- $secret :=  lookup "v1" "Secret" .Release.Namespace $cfg.secretName }}
+{{- if empty $secret | or
+    (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml)
+-}}
+
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $cfg.secretName }}
 data:
-  {{- if $data }}
-  {{ $cfg.writerSecretKey }}: {{ get $data $cfg.writerSecretKey }}
-  {{ $cfg.readerSecretKey }}: {{ get $data $cfg.readerSecretKey }}
-  {{- else }}
+{{- if ($secret).data }}
+  {{ $cfg.writerSecretKey }}: {{ get $secret.data $cfg.writerSecretKey }}
+  {{ $cfg.readerSecretKey }}: {{ get $secret.data $cfg.readerSecretKey }}
+{{- else }}
   {{ $cfg.writerSecretKey }}: {{ randAlphaNum 20 | b64enc }}
   {{ $cfg.readerSecretKey }}: {{ randAlphaNum 20 | b64enc }}
-  {{- end }}
 {{- end }}
 
+{{- end }}
+{{- end }}

--- a/charts/directory/templates/api_keys.yaml
+++ b/charts/directory/templates/api_keys.yaml
@@ -2,7 +2,7 @@
 {{- $cfg := include "aserto-lib.directoryApiKeys" . | fromYaml -}}
 {{- $secret :=  lookup "v1" "Secret" .Release.Namespace $cfg.secretName }}
 {{- if empty $secret | or
-    (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml)
+    (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | eq "true")
 -}}
 
 ---

--- a/charts/directory/templates/config.yaml
+++ b/charts/directory/templates/config.yaml
@@ -109,12 +109,14 @@ stringData:
     authentication:
       authenticators_enabled:
         root_key: true
-        {{- with .Values.oidc }}
+
+      {{- with include "aserto-lib.oidcConfig" . }}
         oidc: true
-        {{- end }}
-        {{- if (.Values.authentication).machineAccounts }}
+      {{- end }}
+
+      {{- if (.Values.authentication).machineAccounts }}
         machine_account: true
-        {{- end }}
+      {{- end }}
 
       root_keys:
       {{- if .Values.tenantDirectory.runService }}
@@ -143,10 +145,10 @@ stringData:
             account: "root-ds"
       {{- end }}
 
-      {{- with .Values.oidc -}}
+    {{- with include "aserto-lib.oidcConfig" . }}
       oidc:
-        {{- include "aserto-lib.oidcConfig" . | nindent 8 }}
-      {{- end }}
+        {{- . | nindent 8 }}
+    {{- end }}
 
       override:
         - methods:

--- a/charts/directory/templates/db_credentials.yaml
+++ b/charts/directory/templates/db_credentials.yaml
@@ -1,6 +1,6 @@
 ---
-{{- $rootSecret := lookup "v1" "Secret" .Release.Namespace .Values.rootDirectory.database.reader.credentialsSecret -}}
-{{- if empty $rootSecret | or (include "aserto-lib.isManagedResource" (list $rootSecret .Release.Name) | toYaml) }}
+{{- $rootSecret := lookup "v1" "Secret" .Release.Namespace .Values.rootDirectory.database.reader.credentialsSecret | default dict -}}
+{{- if empty $rootSecret | or (include "aserto-lib.isManagedResource" (list $rootSecret .Release.Name) | eq "true") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,7 +17,7 @@ data:
 {{- end }}
 ---
 {{- $tenantSecret := lookup "v1" "Secret" .Release.Namespace .Values.tenantDirectory.database.reader.credentialsSecret }}
-{{- if empty $tenantSecret | or (include "aserto-lib.isManagedResource" (list $tenantSecret .Release.Name) | toYaml) }}
+{{- if empty $tenantSecret | or (include "aserto-lib.isManagedResource" (list $tenantSecret .Release.Name) | eq "true") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/directory/templates/db_credentials.yaml
+++ b/charts/directory/templates/db_credentials.yaml
@@ -1,23 +1,34 @@
-{{- $rootData := (lookup "v1" "Secret" .Release.Namespace .Values.rootDirectory.database.reader.credentialsSecret).data -}}
-{{- if empty $rootData }}
 ---
+{{- $rootSecret := lookup "v1" "Secret" .Release.Namespace .Values.rootDirectory.database.reader.credentialsSecret -}}
+{{- if empty $rootSecret | or (include "aserto-lib.isManagedResource" (list $rootSecret .Release.Name) | toYaml) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.rootDirectory.database.reader.credentialsSecret }}
 data:
+{{- if ($rootSecret).data }}
+  username: {{ $rootSecret.data.username }}
+  password: {{ $rootSecret.data.password }}
+{{- else }}
   username: {{ "root_reader" | b64enc }}
   password: {{ randAlphaNum 20 | b64enc}}
 {{- end }}
 
-{{- $tenantData := (lookup "v1" "Secret" .Release.Namespace .Values.tenantDirectory.database.reader.credentialsSecret).data -}}
-{{- if empty $tenantData }}
+{{- end }}
 ---
+{{- $tenantSecret := lookup "v1" "Secret" .Release.Namespace .Values.tenantDirectory.database.reader.credentialsSecret }}
+{{- if empty $tenantSecret | or (include "aserto-lib.isManagedResource" (list $tenantSecret .Release.Name) | toYaml) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.tenantDirectory.database.reader.credentialsSecret }}
 data:
+{{- if ($tenantSecret).data }}
+  username: {{ $tenantSecret.data.username }}
+  password: {{ $tenantSecret.data.password }}
+{{- else }}
   username: {{ "tenant_reader" | b64enc }}
   password: {{ randAlphaNum 20 | b64enc }}
+{{- end }}
+
 {{- end }}

--- a/charts/directory/templates/root_key.yaml
+++ b/charts/directory/templates/root_key.yaml
@@ -5,18 +5,22 @@
 
 {{- $apiKey := $cfg.apiKey -}}
 {{- if empty $apiKey -}}
-  {{- $current :=  (lookup "v1" "Secret" $.Release.Namespace $secretName).data }}
-  {{- if $current }}
-    {{- $apiKey = get $current $secretKey }}
-  {{- else -}}
+  {{- $secret :=  lookup "v1" "Secret" $.Release.Namespace $secretName }}
+  {{- if empty $secret }}
     {{- $apiKey = randAlphaNum 32 | b64enc }}
+  {{- else if (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) -}}
+    {{- $apiKey = get ($secret).data $secretKey }}
   {{- end }}
 {{- end -}}
+
+{{- with $apiKey }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
 data:
-  {{ $secretKey }}: {{ $apiKey }}
+  {{ $secretKey }}: {{ . }}
+{{- end }}
+
 {{- end }}

--- a/charts/directory/templates/root_key.yaml
+++ b/charts/directory/templates/root_key.yaml
@@ -8,7 +8,7 @@
   {{- $secret :=  lookup "v1" "Secret" $.Release.Namespace $secretName }}
   {{- if empty $secret }}
     {{- $apiKey = randAlphaNum 32 | b64enc }}
-  {{- else if (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) -}}
+  {{- else if (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | eq "true") -}}
     {{- $apiKey = get ($secret).data $secretKey }}
   {{- end }}
 {{- end -}}

--- a/charts/discovery/Chart.yaml
+++ b/charts/discovery/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.1.9
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.4"
+appVersion: 0.1.4
 
 dependencies:
   - name: aserto-lib

--- a/charts/discovery/templates/api_keys.yaml
+++ b/charts/discovery/templates/api_keys.yaml
@@ -1,6 +1,6 @@
 {{- $cfg := .Values.apiKey -}}
 {{- $secret :=  lookup "v1" "Secret" .Release.Namespace $cfg.secretName }}
-{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) -}}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | eq "true") -}}
 
 ---
 apiVersion: v1

--- a/charts/discovery/templates/api_keys.yaml
+++ b/charts/discovery/templates/api_keys.yaml
@@ -5,6 +5,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $cfg.secretName }}
-data:  
-  {{ $cfg.secretKey }}: {{ randAlphaNum 20 | b64enc }}  
+data:
+  {{ $cfg.secretKey }}: {{ randAlphaNum 20 | b64enc }}
 {{- end }}

--- a/charts/discovery/templates/api_keys.yaml
+++ b/charts/discovery/templates/api_keys.yaml
@@ -1,10 +1,17 @@
----
 {{- $cfg := .Values.apiKey -}}
-{{- if empty (lookup "v1" "Secret" .Release.Namespace $cfg.secretName).data }}
+{{- $secret :=  lookup "v1" "Secret" .Release.Namespace $cfg.secretName }}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) -}}
+
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $cfg.secretName }}
 data:
+{{- if ($secret).data }}
+  {{ $cfg.secretKey }}: {{ get $secret.data $cfg.secretKey }}
+{{- else }}
   {{ $cfg.secretKey }}: {{ randAlphaNum 20 | b64enc }}
+{{- end }}
+
 {{- end }}

--- a/charts/scim/Chart.yaml
+++ b/charts/scim/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.0.8
+appVersion: 0.0.9
 
 dependencies:
   - name: aserto-lib

--- a/charts/scim/Chart.yaml
+++ b/charts/scim/Chart.yaml
@@ -27,7 +27,7 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.7"
+appVersion: 0.0.8
 
 dependencies:
   - name: aserto-lib

--- a/charts/scim/templates/_helpers.tpl
+++ b/charts/scim/templates/_helpers.tpl
@@ -66,9 +66,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "scim.auth.secretName" -}}
-{{ ((.Values).auth).secretName | default "scim-password" }}
+{{ (.Values.auth).secretName | default "scim-password" }}
 {{- end }}
 
 {{- define "scim.auth.secretKey" -}}
-{{ ((.Values).auth).secretKey | default "password" }}
+{{ (.Values.auth).secretKey | default "password" }}
 {{- end }}

--- a/charts/scim/templates/api_keys.yaml
+++ b/charts/scim/templates/api_keys.yaml
@@ -2,7 +2,7 @@
 {{- $secretName := include "scim.auth.secretName" . -}}
 {{- $secretKey := include "scim.auth.secretKey" . -}}
 {{- $secret :=  lookup "v1" "Secret" .Release.Namespace $secretName }}
-{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) }}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | eq "true") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/scim/templates/api_keys.yaml
+++ b/charts/scim/templates/api_keys.yaml
@@ -1,14 +1,17 @@
 ---
 {{- $secretName := include "scim.auth.secretName" . -}}
 {{- $secretKey := include "scim.auth.secretKey" . -}}
-{{- $data :=  (lookup "v1" "Secret" .Release.Namespace $secretName).data }}
+{{- $secret :=  lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if empty $secret | or (include "aserto-lib.isManagedResource" (list $secret .Release.Name) | toYaml) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
 data:
-  {{- if $data }}
-  {{ $secretKey }}: {{ get $data $secretKey }}
-  {{- else }}
+{{- if ($secret).data }}
+  {{ $secretKey }}: {{ get $secret.data $secretKey }}
+{{- else }}
   {{ $secretKey }}: {{ randAlphaNum 20 | b64enc }}
-  {{- end }}
+{{- end }}
+
+{{- end }}

--- a/charts/scim/templates/config.yaml
+++ b/charts/scim/templates/config.yaml
@@ -14,10 +14,12 @@ stringData:
 
     server:
       listen_address: ":{{ include "scim.port" . }}"
+    {{- with .Values.certSecret -}}
       certs:
         tls_key_path: '/https-certs/tls.key'
         tls_cert_path: '/https-certs/tls.crt'
         tls_ca_cert_path: '/https-certs/ca.crt'
+    {{- end }}
       auth:
         basic:
           enabled: {{ ((.Values.auth).basic).enabled | default "true" }}

--- a/charts/scim/templates/deployment.yaml
+++ b/charts/scim/templates/deployment.yaml
@@ -31,24 +31,20 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+      {{- with .Values.certSecret }}
         - name: https-certs
-          {{- with (include "aserto-lib.httpsConfig" . | fromYaml) }}
-          {{- if .certSecret }}
           secret:
-            secretName: {{ .certSecret }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-          {{- end }}
+            secretName: {{ . }}
+      {{- end }}
 
-        {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}                
+      {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}
         - name: root-ds-grpc-certs
           secret:
             secretName: {{ . }}
             items:
               - key: ca.crt
-                path: ca.crt        
-        {{- end }}
+                path: ca.crt
+      {{- end }}
 
       containers:
         - name: {{ .Chart.Name }}
@@ -58,23 +54,22 @@ spec:
           args: ["run", "--config", "/config/config.yaml"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: https
+            - name: scim
               containerPort: {{ include "scim.port" . }}
           volumeMounts:
             - name: config
               mountPath: /config
               readOnly: true
+          {{- with .Values.certSecret }}
             - name: https-certs
               mountPath: /https-certs
-            {{- if (include "aserto-lib.httpsConfig" . | fromYaml).certSecret  }}
               readOnly: true
-            {{- end }}
-
-            {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}        
+          {{- end }}
+          {{- with ((include "aserto-lib.rootClientCfg" . | fromYaml).caCertSecret).name }}
             - name: root-ds-grpc-certs
               mountPath: /root-ds-grpc-certs
               readOnly: true
-            {{- end }}
+          {{- end }}
           env:
             - name: ASERTO_SCIM_SERVER_AUTH_BASIC_PASSWORD
               valueFrom:
@@ -88,7 +83,7 @@ spec:
                   key: {{ include "scim.auth.secretKey" . }}
             {{- with (include "aserto-lib.rootApiKeyEnv" . | fromYaml) }}
             - name: ASERTO_SCIM_DIRECTORY_API_KEY
-              {{ . | toYaml | nindent 14 }}    
+              {{ . | toYaml | nindent 14 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/scim/templates/service.yaml
+++ b/charts/scim/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: https
+    - name: scim
       port: {{ include "scim.port" . }}
-      targetPort: https
+      targetPort: scim
   selector:
     {{- include "scim.selectorLabels" . | nindent 4 }}

--- a/charts/scim/values.yaml
+++ b/charts/scim/values.yaml
@@ -9,19 +9,15 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: x.y.z
 
-global:
-  aserto:
-    ports:
-      grpc: 8282
-      https: 8383
-      health: 8484
-      metrics: 8585
+# Set the service log level (trace/debug/info/warn/error)
+logLevel: info
 
-    rootDirectory:
-      address: ""
-      caCertSecret: ""
-
+# SCIM port
 port: 8080
+
+# The service doesn't use TLS by default.
+# Specify the name of a certificate of type kubernetes.io/tls to enable TLS.
+certSecret:
 
 # auth:
 #   secretName: scim-password
@@ -46,21 +42,6 @@ rootDirectory:
   disableTLSVerification: false
   caCertSecret: ""
   # address: "{{ .Release.Name }}-aserto-directory.aserto.svc.cluster.local:8282"
-
-
-# Set the service log level (trace/debug/info/warn/error)
-# logLevel: info
-
-https:
-  # The services generates self-signed certificates by default.
-  # To use your own certificate provide the name of a secret
-  # of type kubernetes.io/tls
-  # certSecret: directory-rest-cert
-
-  # read_timeout: 2s
-  # read_header_timeout: 2s
-  # write_timeout: 2s
-  # idle_timeout: 30s
 
 replicaCount: 1
 

--- a/makefile
+++ b/makefile
@@ -63,6 +63,11 @@ lint-%:
 	@echo -e "${ATTN_COLOR}==> lint $* ${NO_COLOR}"
 	@${CT_LINT_CMD} --charts ${CHARTS_DIR}/$*
 
+.PHONY: test-%
+test-%:
+	@echo -e "${ATTN_COLOR}==> test $* ${NO_COLOR}"
+	@uv run --project tools/ktest tools/ktest/ktest.py charts/$*/test/tests.yaml
+
 .PHONY: update-%
 update-%:
 	@echo -e "${ATTN_COLOR}==> update $* ${NO_COLOR}"


### PR DESCRIPTION
This also fixes a bug in the way the charts manage secrets.
Users should be able to create secrets with API keys or database credentials on their own, in which case the charts should not attempt to overwrite them.
With this PR charts create secrets under two conditions:
* The secret doesn't exist. It is created with a randomly generated value.
* The secret exists and was created by a previous deployment of the current release. The secret is left unmodified.