### PR TITLE
serviceName is not part of k8s deployment object

### DIFF
--- a/charts/topaz/templates/deployment.yaml
+++ b/charts/topaz/templates/deployment.yaml
@@ -14,7 +14,9 @@ metadata:
   labels:
     {{- include "topaz.labels" . | nindent 4 }}
 spec:
+  {{- if $persistence }}
   serviceName: {{ include "topaz.fullname" . }}
+  {{- end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}


### PR DESCRIPTION
This PR aims to solve the lint failure due the undefined `serviceName` parameter when persistence is not used 