### PR TITLE
Rename `secrets_vault` to `vault`

### DIFF
--- a/charts/controller/templates/config.yaml
+++ b/charts/controller/templates/config.yaml
@@ -157,8 +157,8 @@ stringData:
             oidc: true
           {{- end }}
 
-    {{- with .Values.secretsVault }}
-    secrets_vault:
+    {{- with .Values.vault }}
+    vault:
       address: {{ .address }}
       insecure: {{ .insecure | default false }}
       root_path: {{ .rootPath | default "/" }}

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -128,20 +128,18 @@ spec:
                   key: password
             {{- end }}
 
-            {{- if .Values.secretsVault }}
-            {{- if .Values.secretsVault.token }}
-            - name: DIRECTORY_SECRETS_VAULT_TOKEN
-              value: {{ .Values.secretsVault.token }}
-            {{- else -}}
-            {{- with .Values.secretsVault.tokenSecret }}
-            - name: DIRECTORY_SECRETS_VAULT_TOKEN
+          {{- with (.Values.vault).token }}
+            - name: DIRECTORY_VAULT_TOKEN
+              value: {{ . }}
+          {{- else -}}
+            {{- with (.Values.vault).tokenSecret }}
+            - name: DIRECTORY_VAULT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- end }}
-            {{- end }}
+          {{- end }}
 
           {{- range $_, $tenant := .Values.tenants -}}
             {{- with $tenant.keysSecret }}

--- a/charts/controller/test/no-tls.values.yaml
+++ b/charts/controller/test/no-tls.values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  tag: 0.33.11-108fc18c-amd64
+  tag: 0.33.13-ce1e7a05-amd64
 
 imagePullSecrets:
   - name: ghcr-creds

--- a/charts/controller/test/tls.values.yaml
+++ b/charts/controller/test/tls.values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  tag: 0.33.11-108fc18c-amd64
+  tag: 0.33.13-ce1e7a05-amd64
 
 imagePullSecrets:
   - name: ghcr-creds

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -71,7 +71,7 @@ tenants:
 #       writerKey: writer
 #       readerKey: reader
 
-# secretsVault:
+# vault:
 #   [Optional] Vault token
 #   token: ""
 #   [Optional] Kubernetes secret containing the vault token

--- a/charts/directory/test/no-tls.values.yaml
+++ b/charts/directory/test/no-tls.values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  tag: 0.33.11-108fc18c-amd64
+  tag: 0.33.13-ce1e7a05-amd64
 
 imagePullSecrets:
   - name: ghcr-creds

--- a/charts/directory/test/tls.values.yaml
+++ b/charts/directory/test/tls.values.yaml
@@ -1,6 +1,6 @@
 ---
 image:
-  tag: 0.33.11-108fc18c-amd64
+  tag: 0.33.13-ce1e7a05-amd64
 
 imagePullSecrets:
   - name: ghcr-creds


### PR DESCRIPTION
The directory already uses `vault` in [its config](https://github.com/aserto-dev/directory/blob/main/pkg/cc/config/config.go#L63) and this commit applies the same change to the controller chart.

